### PR TITLE
Allow write-scoped session model patches

### DIFF
--- a/src/gateway/server-methods.sessions-patch-auth.test.ts
+++ b/src/gateway/server-methods.sessions-patch-auth.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleGatewayRequest } from "./server-methods.js";
+import type { GatewayRequestContext, GatewayRequestHandler } from "./server-methods/types.js";
+
+const noWebchat = () => false;
+
+function buildContext(): GatewayRequestContext {
+  return {
+    logGateway: {
+      warn: vi.fn(),
+    },
+  } as unknown as GatewayRequestContext;
+}
+
+function buildClient(scopes: string[]) {
+  return {
+    connect: {
+      role: "operator",
+      scopes,
+      client: {
+        id: "openclaw-control-ui",
+        version: "1.0.0",
+        platform: "web",
+        mode: "webchat",
+      },
+      minProtocol: 1,
+      maxProtocol: 1,
+    },
+    connId: "conn-1",
+  } satisfies Parameters<typeof handleGatewayRequest>[0]["client"];
+}
+
+async function runSessionsPatch(params: Record<string, unknown>, scopes: string[]) {
+  const respond = vi.fn();
+  const handlerCalls = vi.fn();
+  const handler: GatewayRequestHandler = (opts) => {
+    handlerCalls(opts.params);
+    opts.respond(true, { ok: true }, undefined);
+  };
+
+  await handleGatewayRequest({
+    req: {
+      type: "req",
+      id: "req-1",
+      method: "sessions.patch",
+      params,
+    },
+    respond,
+    client: buildClient(scopes),
+    isWebchatConnect: noWebchat,
+    context: buildContext(),
+    extraHandlers: {
+      "sessions.patch": handler,
+    },
+  });
+
+  return { respond, handlerCalls };
+}
+
+describe("sessions.patch gateway authorization", () => {
+  it("allows operator.write clients to update session UI fields", async () => {
+    const { respond, handlerCalls } = await runSessionsPatch(
+      {
+        key: "agent:main:main",
+        label: "Main",
+        model: "openai-codex/gpt-5.4",
+        thinkingLevel: "medium",
+      },
+      ["operator.write"],
+    );
+
+    expect(handlerCalls).toHaveBeenCalledWith({
+      key: "agent:main:main",
+      label: "Main",
+      model: "openai-codex/gpt-5.4",
+      thinkingLevel: "medium",
+    });
+    expect(respond).toHaveBeenCalledWith(true, { ok: true }, undefined);
+  });
+
+  it("keeps non-UI session patch fields admin-gated", async () => {
+    const { respond, handlerCalls } = await runSessionsPatch(
+      {
+        key: "agent:main:main",
+        model: "openai-codex/gpt-5.4",
+        execHost: "gateway",
+      },
+      ["operator.write"],
+    );
+
+    expect(handlerCalls).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: "missing scope: operator.admin",
+      }),
+    );
+  });
+
+  it("still rejects session UI patches without operator.write or operator.admin", async () => {
+    const { respond, handlerCalls } = await runSessionsPatch(
+      {
+        key: "agent:main:main",
+        model: "openai-codex/gpt-5.4",
+      },
+      ["operator.read"],
+    );
+
+    expect(handlerCalls).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: "missing scope: operator.admin",
+      }),
+    );
+  });
+});

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -1,7 +1,7 @@
 import { withPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import { formatControlPlaneActor, resolveControlPlaneActor } from "./control-plane-audit.js";
 import { consumeControlPlaneWriteBudget } from "./control-plane-rate-limit.js";
-import { ADMIN_SCOPE, authorizeOperatorScopesForMethod } from "./method-scopes.js";
+import { ADMIN_SCOPE, WRITE_SCOPE, authorizeOperatorScopesForMethod } from "./method-scopes.js";
 import { ErrorCodes, errorShape } from "./protocol/index.js";
 import { isRoleAuthorizedForMethod, parseGatewayRole } from "./role-policy.js";
 import { agentHandlers } from "./server-methods/agent.js";
@@ -42,7 +42,24 @@ import { webHandlers } from "./server-methods/web.js";
 import { wizardHandlers } from "./server-methods/wizard.js";
 
 const CONTROL_PLANE_WRITE_METHODS = new Set(["config.apply", "config.patch", "update.run"]);
-function authorizeGatewayMethod(method: string, client: GatewayRequestOptions["client"]) {
+const WRITE_SCOPED_SESSION_PATCH_KEYS = new Set(["key", "label", "model", "thinkingLevel"]);
+
+function isWriteScopedSessionPatch(method: string, params: unknown): boolean {
+  if (method !== "sessions.patch") {
+    return false;
+  }
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    return false;
+  }
+  const keys = Object.keys(params);
+  return keys.length > 0 && keys.every((key) => WRITE_SCOPED_SESSION_PATCH_KEYS.has(key));
+}
+
+function authorizeGatewayMethod(
+  method: string,
+  client: GatewayRequestOptions["client"],
+  params: unknown,
+) {
   if (!client?.connect) {
     return null;
   }
@@ -66,6 +83,13 @@ function authorizeGatewayMethod(method: string, client: GatewayRequestOptions["c
   }
   const scopeAuth = authorizeOperatorScopesForMethod(method, scopes);
   if (!scopeAuth.allowed) {
+    if (
+      scopeAuth.missingScope === ADMIN_SCOPE &&
+      scopes.includes(WRITE_SCOPE) &&
+      isWriteScopedSessionPatch(method, params)
+    ) {
+      return null;
+    }
     return errorShape(ErrorCodes.INVALID_REQUEST, `missing scope: ${scopeAuth.missingScope}`);
   }
   return null;
@@ -113,7 +137,7 @@ export async function handleGatewayRequest(
   opts: GatewayRequestOptions & { extraHandlers?: GatewayRequestHandlers },
 ): Promise<void> {
   const { req, respond, client, isWebchatConnect, context } = opts;
-  const authError = authorizeGatewayMethod(req.method, client);
+  const authError = authorizeGatewayMethod(req.method, client, req.params);
   if (authError) {
     respond(false, undefined, authError);
     return;


### PR DESCRIPTION
## Summary\n- allow operator.write clients to call sessions.patch when the patch is limited to UI-owned session fields: label, model, thinkingLevel\n- keep mixed/admin-only patch fields, such as execHost, gated behind operator.admin\n- add regression coverage for the ZeusChat dropdown authorization failure\n\n## Verification\n- node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-methods.sessions-patch-auth.test.ts src/gateway/method-scopes.test.ts\n\nTracking: ihnotic/zeuschat#5\n