### PR TITLE
fix: drop stale OpenAI tool-call replay turns

### DIFF
--- a/src/agents/openai-ws-request.ts
+++ b/src/agents/openai-ws-request.ts
@@ -89,8 +89,10 @@ export function planOpenAIWebSocketRequestPayload(params: {
     ? params.previousRequestPayload.input
     : [];
   const previousResponseInputItems = params.previousResponseInputItems ?? [];
+  const usesProviderResponseStore = params.fullPayload.store !== false;
 
   if (
+    usesProviderResponseStore &&
     params.previousResponseId &&
     params.previousRequestPayload &&
     payloadFieldsMatch(params.fullPayload, params.previousRequestPayload)

--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -1787,7 +1787,7 @@ describe("planOpenAIWebSocketRequestPayload", () => {
     const previousRequest: ResponseCreateEvent = {
       type: "response.create",
       model: "gpt-5.4",
-      store: false,
+      store: true,
       instructions: "You are helpful.",
       input: previousInputItems,
     };
@@ -1797,7 +1797,7 @@ describe("planOpenAIWebSocketRequestPayload", () => {
     const fullPayload: ResponseCreateEvent = {
       type: "response.create",
       model: "gpt-5.4",
-      store: false,
+      store: true,
       instructions: "You are helpful.",
       input: [
         ...previousInputItems,
@@ -1816,6 +1816,39 @@ describe("planOpenAIWebSocketRequestPayload", () => {
     expect(plan.mode).toBe("incremental");
     expect(plan.payload.previous_response_id).toBe("resp_prev");
     expect(plan.payload.input).toEqual([{ type: "message", role: "user", content: "Next" }]);
+  });
+
+  it("uses full context when the provider response store is disabled", () => {
+    const previousInputItems: InputItem[] = [{ type: "message", role: "user", content: "Hello" }];
+    const previousRequest: ResponseCreateEvent = {
+      type: "response.create",
+      model: "gpt-5.4",
+      store: false,
+      instructions: "You are helpful.",
+      input: previousInputItems,
+    };
+    const previousResponseInputItems: InputItem[] = [
+      { type: "message", role: "assistant", content: "Hi" },
+    ];
+    const fullPayload: ResponseCreateEvent = {
+      ...previousRequest,
+      input: [
+        ...previousInputItems,
+        ...previousResponseInputItems,
+        { type: "message", role: "user", content: "Next" },
+      ],
+    };
+
+    const plan = planOpenAIWebSocketRequestPayload({
+      fullPayload,
+      previousRequestPayload: previousRequest,
+      previousResponseId: "resp_prev",
+      previousResponseInputItems,
+    });
+
+    expect(plan.mode).toBe("full_context");
+    expect(plan.payload.previous_response_id).toBeUndefined();
+    expect(plan.payload.input).toEqual(fullPayload.input);
   });
 
   it("falls back to full context when non-input fields differ", () => {
@@ -2909,7 +2942,7 @@ describe("createOpenAIWebSocketStreamFn", () => {
     }
   });
 
-  it("tracks previous_response_id across turns (incremental send)", async () => {
+  it("uses full context across turns when Responses store is disabled", async () => {
     const sessionId = "sess-incremental";
     const streamFn = createOpenAIWebSocketStreamFn("sk-test", sessionId);
 
@@ -2940,7 +2973,7 @@ describe("createOpenAIWebSocketStreamFn", () => {
     manager.simulateEvent({ type: "response.completed", response: turn1Response });
     await done1;
 
-    // ── Turn 2: incremental (tool results only) ───────────────────────────
+    // ── Turn 2: full context because store:false cannot rely on response-chain deltas ────────
     const ctx2 = {
       systemPrompt: "You are helpful.",
       messages: [
@@ -2970,20 +3003,18 @@ describe("createOpenAIWebSocketStreamFn", () => {
     });
     await done2;
 
-    // Turn 2 should have sent previous_response_id and only tool results
+    // Turn 2 should replay the full context without previous_response_id.
     expect(manager.sentEvents).toHaveLength(2);
     const sent2 = manager.sentEvents[1] as {
       previous_response_id?: string;
       input: Array<{ type: string }>;
     };
-    expect(sent2.previous_response_id).toBe("resp_turn1");
-    // Input should only contain tool results, not the full history
+    expect(sent2.previous_response_id).toBeUndefined();
     const inputTypes = (sent2.input ?? []).map((i) => i.type);
-    expect(inputTypes.every((t) => t === "function_call_output")).toBe(true);
-    expect(inputTypes).toHaveLength(1);
+    expect(inputTypes).toEqual(["message", "function_call", "function_call_output"]);
   });
 
-  it("sends only a follow-up user message when the full context is a strict extension", async () => {
+  it("sends full context for a follow-up user message when Responses store is disabled", async () => {
     const sessionId = "sess-user-delta";
     const streamFn = createOpenAIWebSocketStreamFn("sk-test", sessionId);
 
@@ -3040,11 +3071,15 @@ describe("createOpenAIWebSocketStreamFn", () => {
       previous_response_id?: string;
       input: Array<{ type: string; role?: string; content?: unknown }>;
     };
-    expect(sent2.previous_response_id).toBe("resp_turn1_text");
-    expect(sent2.input).toEqual([{ type: "message", role: "user", content: "What can you do?" }]);
+    expect(sent2.previous_response_id).toBeUndefined();
+    expect(sent2.input).toEqual([
+      { type: "message", role: "user", content: "Hello" },
+      { type: "message", role: "assistant", content: "Hi there." },
+      { type: "message", role: "user", content: "What can you do?" },
+    ]);
   });
 
-  it("uses an empty incremental payload when replay context exactly matches the response chain", async () => {
+  it("replays the response chain when Responses store is disabled", async () => {
     const sessionId = "sess-full-context-replay";
     const streamFn = createOpenAIWebSocketStreamFn("sk-test", sessionId);
 
@@ -3122,8 +3157,8 @@ describe("createOpenAIWebSocketStreamFn", () => {
       previous_response_id?: string;
       input: Array<{ type: string; id?: string; call_id?: string }>;
     };
-    expect(sent2.previous_response_id).toBe("resp_turn1_reasoning");
-    expect(sent2.input).toEqual([]);
+    expect(sent2.previous_response_id).toBeUndefined();
+    expect(sent2.input.map((item) => item.type)).toEqual(["message", "reasoning", "function_call"]);
   });
 
   it("replays encrypted-only reasoning when websocket must send full context", async () => {

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -687,7 +687,7 @@ describe("sanitizeSessionHistory", () => {
     expect(result[1]?.role).toBe("assistant");
   });
 
-  it("synthesizes Codex-style aborted tool results for openai-responses after repair", async () => {
+  it("drops incomplete tool-call turns for openai-responses after repair", async () => {
     const messages: AgentMessage[] = [
       makeUserMessage("start"),
       makeAssistantMessage([{ type: "toolCall", id: "call_1", name: "read", arguments: {} }], {
@@ -698,20 +698,11 @@ describe("sanitizeSessionHistory", () => {
 
     const result = await sanitizeOpenAIHistory(messages);
 
-    expect(result.map((message) => message.role)).toEqual([
-      "user",
-      "assistant",
-      "toolResult",
-      "user",
-    ]);
-    expect((result[2] as { toolCallId?: string }).toolCallId).toBe("call1");
-    expect((result[2] as Extract<AgentMessage, { role: "toolResult" }>).content).toEqual([
-      { type: "text", text: "aborted" },
-    ]);
-    expect(JSON.stringify(result)).not.toContain("missing tool result");
+    expect(result.map((message) => message.role)).toEqual(["user", "user"]);
+    expect(JSON.stringify(result)).not.toContain("call1");
   });
 
-  it("synthesizes Codex-style aborted tool results for openai-codex-responses", async () => {
+  it("drops incomplete tool-call turns for openai-codex-responses", async () => {
     const messages: AgentMessage[] = [
       makeAssistantMessage(
         [
@@ -732,25 +723,12 @@ describe("sanitizeSessionHistory", () => {
       sessionId: TEST_SESSION_ID,
     });
 
-    expect(result.map((message) => message.role)).toEqual([
-      "assistant",
-      "toolResult",
-      "toolResult",
-      "toolResult",
-      "user",
-    ]);
-    expect(
-      result.slice(1, 4).map((message) => (message as { toolCallId?: string }).toolCallId),
-    ).toEqual(["calla", "callb", "callc"]);
-    for (const message of result.slice(1, 4)) {
-      expect((message as Extract<AgentMessage, { role: "toolResult" }>).content).toEqual([
-        { type: "text", text: "aborted" },
-      ]);
-    }
-    expect(JSON.stringify(result)).not.toContain("missing tool result");
+    expect(result.map((message) => message.role)).toEqual(["user"]);
+    expect(JSON.stringify(result)).not.toContain("calla");
+    expect(JSON.stringify(result)).not.toContain("aborted");
   });
 
-  it("keeps real parallel tool results for openai-responses and aborts missing siblings", async () => {
+  it("drops partial parallel tool turns for openai-responses instead of replaying stale siblings", async () => {
     const messages: AgentMessage[] = [
       makeAssistantMessage(
         [
@@ -772,36 +750,13 @@ describe("sanitizeSessionHistory", () => {
 
     const result = await sanitizeOpenAIHistory(messages);
 
-    expect(result.map((message) => message.role)).toEqual([
-      "assistant",
-      "toolResult",
-      "toolResult",
-      "toolResult",
-      "user",
-    ]);
-    expect(
-      extractToolCallsFromAssistant(result[0] as Extract<AgentMessage, { role: "assistant" }>),
-    ).toMatchObject([
-      { id: "call1", name: "read" },
-      { id: "call2", name: "exec" },
-      { id: "call3", name: "write" },
-    ]);
-    expect(
-      result.slice(1, 4).map((message) => (message as { toolCallId?: string }).toolCallId),
-    ).toEqual(["call1", "call2", "call3"]);
-    expect((result[1] as Extract<AgentMessage, { role: "toolResult" }>).content).toEqual([
-      { type: "text", text: "aborted" },
-    ]);
-    expect((result[2] as Extract<AgentMessage, { role: "toolResult" }>).content).toEqual([
-      { type: "text", text: "ok" },
-    ]);
-    expect((result[3] as Extract<AgentMessage, { role: "toolResult" }>).content).toEqual([
-      { type: "text", text: "aborted" },
-    ]);
-    expect(JSON.stringify(result)).not.toContain("missing tool result");
+    expect(result.map((message) => message.role)).toEqual(["user"]);
+    expect(JSON.stringify(result)).not.toContain("call1");
+    expect(JSON.stringify(result)).not.toContain("call2");
+    expect(JSON.stringify(result)).not.toContain("aborted");
   });
 
-  it("applies aborted missing-result repair to azure-openai-responses", async () => {
+  it("drops incomplete tool-call turns for azure-openai-responses", async () => {
     const messages: AgentMessage[] = [
       makeAssistantMessage([{ type: "toolCall", id: "call_azure", name: "read", arguments: {} }], {
         stopReason: "toolUse",
@@ -817,11 +772,8 @@ describe("sanitizeSessionHistory", () => {
       sessionId: TEST_SESSION_ID,
     });
 
-    expect(result.map((message) => message.role)).toEqual(["assistant", "toolResult", "user"]);
-    expect((result[1] as { toolCallId?: string }).toolCallId).toBe("callazure");
-    expect((result[1] as Extract<AgentMessage, { role: "toolResult" }>).content).toEqual([
-      { type: "text", text: "aborted" },
-    ]);
+    expect(result.map((message) => message.role)).toEqual(["user"]);
+    expect(JSON.stringify(result)).not.toContain("callazure");
   });
 
   it("drops duplicate and orphan OpenAI outputs while preserving the first real result", async () => {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -979,7 +979,12 @@ export async function compactEmbeddedPiSessionDirect(
                 ...(model.api === "openai-responses" ||
                 model.api === "azure-openai-responses" ||
                 model.api === "openai-codex-responses"
-                  ? { missingToolResultText: "aborted" }
+                  ? {
+                      missingToolResultPolicy: transcriptPolicy.allowSyntheticToolResults
+                        ? "synthesize"
+                        : "drop_assistant_turn",
+                      missingToolResultText: "aborted",
+                    }
                   : {}),
               })
             : truncated;

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -661,6 +661,9 @@ export async function sanitizeSessionHistory(params: {
     isOpenAIResponsesApi && policy.repairToolUseResultPairing
       ? sanitizeToolUseResultPairing(sanitizedToolCalls, {
           erroredAssistantResultPolicy: "drop",
+          missingToolResultPolicy: policy.allowSyntheticToolResults
+            ? "synthesize"
+            : "drop_assistant_turn",
           // Match upstream Codex history normalization for OpenAI Responses:
           // missing function_call_output entries are model-visible "aborted".
           missingToolResultText: "aborted",

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1886,7 +1886,16 @@ export async function runEmbeddedAttempt(
           // Strip orphaned reasoning blocks first, then fix function-call
           // pairing — matches the call order in google.ts.
           const reasoningSanitized = downgradeOpenAIReasoningBlocks(messages as AgentMessage[]);
-          const sanitized = downgradeOpenAIFunctionCallReasoningPairs(reasoningSanitized);
+          const paired = transcriptPolicy.repairToolUseResultPairing
+            ? sanitizeToolUseResultPairing(reasoningSanitized, {
+                erroredAssistantResultPolicy: "drop",
+                missingToolResultPolicy: transcriptPolicy.allowSyntheticToolResults
+                  ? "synthesize"
+                  : "drop_assistant_turn",
+                missingToolResultText: "aborted",
+              })
+            : reasoningSanitized;
+          const sanitized = downgradeOpenAIFunctionCallReasoningPairs(paired);
           if (sanitized === messages) {
             return inner(model, context, options);
           }
@@ -2045,7 +2054,14 @@ export async function runEmbeddedAttempt(
           const limited = transcriptPolicy.repairToolUseResultPairing
             ? sanitizeToolUseResultPairing(truncated, {
                 erroredAssistantResultPolicy: "drop",
-                ...(isOpenAIResponsesApi ? { missingToolResultText: "aborted" } : {}),
+                ...(isOpenAIResponsesApi
+                  ? {
+                      missingToolResultPolicy: transcriptPolicy.allowSyntheticToolResults
+                        ? "synthesize"
+                        : "drop_assistant_turn",
+                      missingToolResultText: "aborted",
+                    }
+                  : {}),
               })
             : truncated;
           cacheTrace?.recordStage("session:limited", { messages: limited });

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -94,6 +94,25 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(result.added[0]?.content).toEqual([{ type: "text", text: "aborted" }]);
   });
 
+  it("can drop assistant tool-call turns with missing results", () => {
+    const input = castAgentMessages([
+      { role: "user", content: "first" },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      },
+      { role: "user", content: "next question" },
+    ]);
+
+    const result = repairToolUseResultPairing(input, {
+      missingToolResultPolicy: "drop_assistant_turn",
+    });
+
+    expect(result.added).toHaveLength(0);
+    expect(result.messages.map((m) => m.role)).toEqual(["user", "user"]);
+    expect(JSON.stringify(result.messages)).not.toContain("call_1");
+  });
+
   it("keeps matched parallel tool results and synthesizes only missing siblings", () => {
     const input = castAgentMessages([
       {

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -259,9 +259,11 @@ export type ToolCallInputRepairOptions = {
 };
 
 export type ErroredAssistantResultPolicy = "preserve" | "drop";
+export type MissingToolResultPolicy = "synthesize" | "drop_assistant_turn";
 
 export type ToolUseResultPairingOptions = {
   erroredAssistantResultPolicy?: ErroredAssistantResultPolicy;
+  missingToolResultPolicy?: MissingToolResultPolicy;
   missingToolResultText?: string;
 };
 
@@ -444,6 +446,10 @@ function shouldDropErroredAssistantResults(options?: ToolUseResultPairingOptions
   return options?.erroredAssistantResultPolicy === "drop";
 }
 
+function shouldDropAssistantTurnWithMissingResults(options?: ToolUseResultPairingOptions): boolean {
+  return options?.missingToolResultPolicy === "drop_assistant_turn";
+}
+
 export function repairToolUseResultPairing(
   messages: AgentMessage[],
   options?: ToolUseResultPairingOptions,
@@ -574,6 +580,16 @@ export function repairToolUseResultPairing(
       } else {
         changed = true;
       }
+      for (const rem of remainder) {
+        out.push(rem);
+      }
+      i = j - 1;
+      continue;
+    }
+
+    const missingToolCalls = toolCalls.filter((call) => !spanResultsById.has(call.id));
+    if (missingToolCalls.length > 0 && shouldDropAssistantTurnWithMissingResults(options)) {
+      changed = true;
       for (const rem of remainder) {
         out.push(rem);
       }

--- a/src/agents/transport-message-transform.ts
+++ b/src/agents/transport-message-transform.ts
@@ -115,7 +115,10 @@ export function transformTransportMessages(
   const replayable = transformed.filter((msg) => !isFailedAssistantTurn(msg));
 
   if (!allowSyntheticToolResults) {
-    return replayable;
+    return repairToolUseResultPairing(replayable, {
+      erroredAssistantResultPolicy: "drop",
+      missingToolResultPolicy: "drop_assistant_turn",
+    }).messages as Context["messages"];
   }
 
   // PI's local transform can synthesize missing results, but it does not move


### PR DESCRIPTION
## Summary
- drop incomplete assistant tool-call turns from OpenAI/Responses replay when synthetic tool results are disabled
- avoid `previous_response_id` incremental deltas when the Responses provider store is disabled with `store:false`
- apply replay repair in history sanitization, truncation repair, compaction, and transport transforms
- update regression coverage for stale tool-call replay and store-disabled Responses continuations

## Verification
- Local: `npx --yes pnpm@10.33.2 exec vitest run src/agents/openai-ws-stream.test.ts src/agents/session-transcript-repair.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts`
- Zeus: same focused suite passed, 5 files / 380 tests
- Zeus: `npx --yes pnpm@10.33.2 build`
- Zeus: `npx --yes pnpm@10.33.2 ui:build`
- Zeus: gateway restarted and `openclaw channels status --probe --json` reports Telegram running with probe ok
- Live canary: `agent:main:telegram:direct:8599953238` answered the current Plex question correctly after the patch: `No — I checked “Once Upon a Time in Hollywood” and it is not on Plex.`

Tracking: ihnotic/openclaw#3; ihnotic/zeusbot#117
