### PR TITLE
fix: prevent Telegram status-tool drift after answers

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -2011,13 +2011,13 @@ export async function runEmbeddedPiAgent(
           const assistantForFinalPayload = resolveAssistantForFinalPayload({
             currentAttemptAssistant,
             sessionLastAssistant,
-            previousAssistantBeforeCurrentPrompt: attempt.previousAssistantBeforeCurrentPrompt,
+            previousAssistantBeforeTurn: attempt.previousAssistantBeforeTurn,
             replayInvalid,
           });
           const assistantTextsForFinalPayload = resolveAssistantTextsForFinalPayload({
             assistantTexts: attempt.assistantTexts,
             currentAttemptAssistant,
-            previousAssistantBeforeCurrentPrompt: attempt.previousAssistantBeforeCurrentPrompt,
+            previousAssistantBeforeTurn: attempt.previousAssistantBeforeTurn,
             finalPromptText: attempt.finalPromptText,
             replayInvalid,
           });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -108,6 +108,7 @@ import {
   buildUsageAgentMetaFields,
   createCompactionDiagId,
   resolveActiveErrorContext,
+  resolveAssistantForFinalPayload,
   resolveFinalAssistantRawText,
   resolveFinalAssistantVisibleText,
   resolveMaxRunRetryIterations,
@@ -2005,13 +2006,20 @@ export async function runEmbeddedPiAgent(
             compactionCount: autoCompactionCount > 0 ? autoCompactionCount : undefined,
             compactionTokensAfter: lastCompactionTokensAfter,
           };
-          const finalAssistantVisibleText = resolveFinalAssistantVisibleText(sessionLastAssistant);
-          const finalAssistantRawText = resolveFinalAssistantRawText(sessionLastAssistant);
+          const replayInvalid = resolveReplayInvalidForAttempt(null);
+          const assistantForFinalPayload = resolveAssistantForFinalPayload({
+            currentAttemptAssistant,
+            sessionLastAssistant,
+            replayInvalid,
+          });
+          const finalAssistantVisibleText =
+            resolveFinalAssistantVisibleText(assistantForFinalPayload);
+          const finalAssistantRawText = resolveFinalAssistantRawText(assistantForFinalPayload);
 
           const payloads = buildEmbeddedRunPayloads({
             assistantTexts: attempt.assistantTexts,
             toolMetas: attempt.toolMetas,
-            lastAssistant: attempt.lastAssistant,
+            lastAssistant: assistantForFinalPayload,
             lastToolError: attempt.lastToolError,
             config: params.config,
             isCronTrigger: params.trigger === "cron",
@@ -2459,7 +2467,6 @@ export async function runEmbeddedPiAgent(
               agentDir: params.agentDir,
             });
           }
-          const replayInvalid = resolveReplayInvalidForAttempt(null);
           const livenessState = attempt.yieldDetected
             ? "paused"
             : resolveRunLivenessState({

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -109,6 +109,7 @@ import {
   createCompactionDiagId,
   resolveActiveErrorContext,
   resolveAssistantForFinalPayload,
+  resolveAssistantTextsForFinalPayload,
   resolveFinalAssistantRawText,
   resolveFinalAssistantVisibleText,
   resolveMaxRunRetryIterations,
@@ -2010,6 +2011,14 @@ export async function runEmbeddedPiAgent(
           const assistantForFinalPayload = resolveAssistantForFinalPayload({
             currentAttemptAssistant,
             sessionLastAssistant,
+            previousAssistantBeforeCurrentPrompt: attempt.previousAssistantBeforeCurrentPrompt,
+            replayInvalid,
+          });
+          const assistantTextsForFinalPayload = resolveAssistantTextsForFinalPayload({
+            assistantTexts: attempt.assistantTexts,
+            currentAttemptAssistant,
+            previousAssistantBeforeCurrentPrompt: attempt.previousAssistantBeforeCurrentPrompt,
+            finalPromptText: attempt.finalPromptText,
             replayInvalid,
           });
           const finalAssistantVisibleText =
@@ -2017,7 +2026,7 @@ export async function runEmbeddedPiAgent(
           const finalAssistantRawText = resolveFinalAssistantRawText(assistantForFinalPayload);
 
           const payloads = buildEmbeddedRunPayloads({
-            assistantTexts: attempt.assistantTexts,
+            assistantTexts: assistantTextsForFinalPayload,
             toolMetas: attempt.toolMetas,
             lastAssistant: assistantForFinalPayload,
             lastToolError: attempt.lastToolError,

--- a/src/agents/pi-embedded-runner/run/attempt.context-engine-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.context-engine-helpers.ts
@@ -2,6 +2,7 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import type { ContextEngine } from "../../../context-engine/types.js";
 import type { BootstrapMode } from "../../bootstrap-mode.js";
+import { extractAssistantVisibleText } from "../../pi-embedded-utils.js";
 import { normalizeUsage, type NormalizedUsage } from "../../usage.js";
 import type { PromptCacheChange } from "../prompt-cache-observability.js";
 import type { EmbeddedRunAttemptResult } from "./types.js";
@@ -111,6 +112,41 @@ export function findCurrentAttemptAssistantMessage(params: {
     .slice(Math.max(0, params.prePromptMessageCount))
     .toReversed()
     .find((message): message is AssistantMessage => message.role === "assistant");
+}
+
+function isAssistantWithVisibleText(message: AgentMessage): message is AssistantMessage {
+  return (
+    message.role === "assistant" &&
+    Boolean(extractAssistantVisibleText(message as AssistantMessage).trim())
+  );
+}
+
+export function findPreviousAssistantBeforeTurn(params: {
+  messagesSnapshot: AgentMessage[];
+  prePromptMessageCount: number;
+}): AssistantMessage | undefined {
+  const previousVisibleAssistantByCount = params.messagesSnapshot
+    .slice(0, Math.max(0, params.prePromptMessageCount))
+    .toReversed()
+    .find(isAssistantWithVisibleText);
+  if (previousVisibleAssistantByCount) {
+    return previousVisibleAssistantByCount;
+  }
+
+  const lastAssistantIndex = params.messagesSnapshot.findLastIndex(
+    (message) => message.role === "assistant",
+  );
+  const latestUserIndexBeforeLastAssistant = params.messagesSnapshot.findLastIndex(
+    (message, index) =>
+      message.role === "user" && (lastAssistantIndex < 0 || index < lastAssistantIndex),
+  );
+  if (latestUserIndexBeforeLastAssistant < 0) {
+    return undefined;
+  }
+  return params.messagesSnapshot
+    .slice(0, latestUserIndexBeforeLastAssistant)
+    .toReversed()
+    .find(isAssistantWithVisibleText);
 }
 
 function parsePromptCacheTouchTimestamp(value: unknown): number | null {

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -14,6 +14,7 @@ import {
   assembleAttemptContextEngine,
   buildContextEnginePromptCacheInfo,
   findCurrentAttemptAssistantMessage,
+  findPreviousAssistantBeforeTurn,
   finalizeAttemptContextEngineTurn,
   resolvePromptCacheTouchTimestamp,
   runAttemptContextEngineBootstrap,
@@ -656,6 +657,62 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
 
     expect(currentAttemptAssistant).toBeUndefined();
     expect(promptCache).toEqual({ retention: "short" });
+  });
+
+  it("finds the visible assistant before a user turn across post-tool prompt loops", () => {
+    const priorAssistant = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "prior final answer",
+          textSignature: JSON.stringify({ v: 1, id: "prior_final", phase: "final_answer" }),
+        },
+      ],
+    } as unknown as AgentMessage;
+    const userMessage = { role: "user", content: "current question" } as unknown as AgentMessage;
+    const toolUseAssistant = {
+      role: "assistant",
+      stopReason: "toolUse",
+      content: [{ type: "toolCall", name: "exec", id: "call_1", arguments: {} }],
+    } as unknown as AgentMessage;
+    const toolResult = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      content: [{ type: "text", text: "current tool answer" }],
+    } as unknown as AgentMessage;
+    const currentAssistant = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "current tool answer",
+          textSignature: JSON.stringify({
+            v: 1,
+            id: "current_commentary",
+            phase: "commentary",
+          }),
+        },
+        {
+          type: "text",
+          text: "prior final answer",
+          textSignature: JSON.stringify({ v: 1, id: "current_final", phase: "final_answer" }),
+        },
+      ],
+    } as unknown as AgentMessage;
+
+    expect(
+      findPreviousAssistantBeforeTurn({
+        messagesSnapshot: [
+          priorAssistant,
+          userMessage,
+          toolUseAssistant,
+          toolResult,
+          currentAssistant,
+        ],
+        prePromptMessageCount: 4,
+      }),
+    ).toBe(priorAssistant);
   });
 
   it("derives live loop prompt-cache info from the current attempt assistant", () => {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AssistantMessage } from "@mariozechner/pi-ai";
 import {
   createAgentSession,
   DefaultResourceLoader,
@@ -2271,6 +2272,7 @@ export async function runEmbeddedAttempt(
       };
       let lastAssistant: AgentMessage | undefined;
       let currentAttemptAssistant: EmbeddedRunAttemptResult["currentAttemptAssistant"];
+      let previousAssistantBeforeCurrentPrompt: EmbeddedRunAttemptResult["previousAssistantBeforeCurrentPrompt"];
       let attemptUsage: NormalizedUsage | undefined;
       let cacheBreak: ReturnType<typeof completePromptCacheObservation> = null;
       let promptCache: EmbeddedRunAttemptResult["promptCache"];
@@ -3072,6 +3074,10 @@ export async function runEmbeddedAttempt(
           .slice()
           .toReversed()
           .find((m) => m.role === "assistant");
+        previousAssistantBeforeCurrentPrompt = messagesSnapshot
+          .slice(0, Math.max(0, prePromptMessageCount))
+          .toReversed()
+          .find((message): message is AssistantMessage => message.role === "assistant");
         currentAttemptAssistant = findCurrentAttemptAssistantMessage({
           messagesSnapshot,
           prePromptMessageCount,
@@ -3452,6 +3458,7 @@ export async function runEmbeddedAttempt(
         toolMetas: toolMetasNormalized,
         lastAssistant,
         currentAttemptAssistant,
+        previousAssistantBeforeCurrentPrompt,
         lastToolError: getLastToolError?.(),
         didSendViaMessagingTool: didSendViaMessagingTool(),
         messagingToolSentTexts: getMessagingToolSentTexts(),

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2,7 +2,6 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import type { AssistantMessage } from "@mariozechner/pi-ai";
 import {
   createAgentSession,
   DefaultResourceLoader,
@@ -252,6 +251,7 @@ import {
   buildLoopPromptCacheInfo,
   buildContextEnginePromptCacheInfo,
   findCurrentAttemptAssistantMessage,
+  findPreviousAssistantBeforeTurn,
   finalizeAttemptContextEngineTurn,
   resolvePromptCacheTouchTimestamp,
   resolveAttemptBootstrapContext,
@@ -3076,10 +3076,10 @@ export async function runEmbeddedAttempt(
           .slice()
           .toReversed()
           .find((m) => m.role === "assistant");
-        previousAssistantBeforeTurn = messagesSnapshot
-          .slice(0, Math.max(0, firstPromptMessageCount ?? prePromptMessageCount))
-          .toReversed()
-          .find((message): message is AssistantMessage => message.role === "assistant");
+        previousAssistantBeforeTurn = findPreviousAssistantBeforeTurn({
+          messagesSnapshot,
+          prePromptMessageCount: firstPromptMessageCount ?? prePromptMessageCount,
+        });
         currentAttemptAssistant = findCurrentAttemptAssistantMessage({
           messagesSnapshot,
           prePromptMessageCount,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1520,6 +1520,7 @@ export async function runEmbeddedAttempt(
           await baseConvertToLlm(normalizeMessagesForLlmBoundary(messages));
       }
       let prePromptMessageCount = activeSession.messages.length;
+      let firstPromptMessageCount: number | undefined;
       let unwindowedContextEngineMessagesForPrecheck: AgentMessage[] | undefined;
       abortSessionForYield = () => {
         yieldAbortSettled = Promise.resolve(activeSession.abort());
@@ -2272,7 +2273,7 @@ export async function runEmbeddedAttempt(
       };
       let lastAssistant: AgentMessage | undefined;
       let currentAttemptAssistant: EmbeddedRunAttemptResult["currentAttemptAssistant"];
-      let previousAssistantBeforeCurrentPrompt: EmbeddedRunAttemptResult["previousAssistantBeforeCurrentPrompt"];
+      let previousAssistantBeforeTurn: EmbeddedRunAttemptResult["previousAssistantBeforeTurn"];
       let attemptUsage: NormalizedUsage | undefined;
       let cacheBreak: ReturnType<typeof completePromptCacheObservation> = null;
       let promptCache: EmbeddedRunAttemptResult["promptCache"];
@@ -2644,6 +2645,7 @@ export async function runEmbeddedAttempt(
             activeSession.agent.state.messages = filteredMessages;
           }
           prePromptMessageCount = activeSession.messages.length;
+          firstPromptMessageCount ??= prePromptMessageCount;
 
           const promptSubmission = resolveRuntimeContextPromptParts({
             effectivePrompt,
@@ -3074,8 +3076,8 @@ export async function runEmbeddedAttempt(
           .slice()
           .toReversed()
           .find((m) => m.role === "assistant");
-        previousAssistantBeforeCurrentPrompt = messagesSnapshot
-          .slice(0, Math.max(0, prePromptMessageCount))
+        previousAssistantBeforeTurn = messagesSnapshot
+          .slice(0, Math.max(0, firstPromptMessageCount ?? prePromptMessageCount))
           .toReversed()
           .find((message): message is AssistantMessage => message.role === "assistant");
         currentAttemptAssistant = findCurrentAttemptAssistantMessage({
@@ -3458,7 +3460,7 @@ export async function runEmbeddedAttempt(
         toolMetas: toolMetasNormalized,
         lastAssistant,
         currentAttemptAssistant,
-        previousAssistantBeforeCurrentPrompt,
+        previousAssistantBeforeTurn,
         lastToolError: getLastToolError?.(),
         didSendViaMessagingTool: didSendViaMessagingTool(),
         messagingToolSentTexts: getMessagingToolSentTexts(),

--- a/src/agents/pi-embedded-runner/run/helpers.test.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.test.ts
@@ -147,7 +147,7 @@ describe("resolveAssistantForFinalPayload", () => {
     expect(
       resolveAssistantForFinalPayload({
         currentAttemptAssistant: currentAssistant,
-        previousAssistantBeforeCurrentPrompt: priorAssistant,
+        previousAssistantBeforeTurn: priorAssistant,
         replayInvalid: true,
       }),
     ).toBeUndefined();
@@ -180,7 +180,7 @@ describe("resolveAssistantTextsForFinalPayload", () => {
       resolveAssistantTextsForFinalPayload({
         assistantTexts: ["QA_MODEL previous ok"],
         currentAttemptAssistant: currentAssistant,
-        previousAssistantBeforeCurrentPrompt: priorAssistant,
+        previousAssistantBeforeTurn: priorAssistant,
         finalPromptText: "QA_PLEX_YES_123456 answer this current prompt",
         replayInvalid: true,
       }),
@@ -212,7 +212,7 @@ describe("resolveAssistantTextsForFinalPayload", () => {
       resolveAssistantTextsForFinalPayload({
         assistantTexts: ["Prior answer"],
         currentAttemptAssistant: currentAssistant,
-        previousAssistantBeforeCurrentPrompt: priorAssistant,
+        previousAssistantBeforeTurn: priorAssistant,
         finalPromptText: "What is the status?",
         replayInvalid: true,
       }),

--- a/src/agents/pi-embedded-runner/run/helpers.test.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.test.ts
@@ -2,8 +2,10 @@ import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
 import {
   resolveAssistantForFinalPayload,
+  resolveAssistantTextsForFinalPayload,
   resolveFinalAssistantRawText,
   resolveFinalAssistantVisibleText,
+  STALE_REPLAY_FINAL_ANSWER_NOTICE,
 } from "./helpers.js";
 
 function makeAssistantMessage(
@@ -119,5 +121,101 @@ describe("resolveAssistantForFinalPayload", () => {
         replayInvalid: true,
       }),
     ).toBe(currentAssistant);
+  });
+
+  it("suppresses a replay-invalid final answer when it repeats the prior final", () => {
+    const priorAssistant = makeAssistantMessage([
+      {
+        type: "text",
+        text: "QA_MODEL previous ok",
+        textSignature: JSON.stringify({ v: 1, id: "prior_final", phase: "final_answer" }),
+      },
+    ]);
+    const currentAssistant = makeAssistantMessage([
+      {
+        type: "text",
+        text: "QA_PLEX current ok",
+        textSignature: JSON.stringify({ v: 1, id: "current_commentary", phase: "commentary" }),
+      },
+      {
+        type: "text",
+        text: "QA_MODEL previous ok",
+        textSignature: JSON.stringify({ v: 1, id: "current_final", phase: "final_answer" }),
+      },
+    ]);
+
+    expect(
+      resolveAssistantForFinalPayload({
+        currentAttemptAssistant: currentAssistant,
+        previousAssistantBeforeCurrentPrompt: priorAssistant,
+        replayInvalid: true,
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("resolveAssistantTextsForFinalPayload", () => {
+  it("promotes current anchored commentary when replay-invalid final text repeats the prior answer", () => {
+    const priorAssistant = makeAssistantMessage([
+      {
+        type: "text",
+        text: "QA_MODEL previous ok",
+        textSignature: JSON.stringify({ v: 1, id: "prior_final", phase: "final_answer" }),
+      },
+    ]);
+    const currentAssistant = makeAssistantMessage([
+      {
+        type: "text",
+        text: "QA_PLEX_YES_123456 current ok",
+        textSignature: JSON.stringify({ v: 1, id: "current_commentary", phase: "commentary" }),
+      },
+      {
+        type: "text",
+        text: "QA_MODEL previous ok",
+        textSignature: JSON.stringify({ v: 1, id: "current_final", phase: "final_answer" }),
+      },
+    ]);
+
+    expect(
+      resolveAssistantTextsForFinalPayload({
+        assistantTexts: ["QA_MODEL previous ok"],
+        currentAttemptAssistant: currentAssistant,
+        previousAssistantBeforeCurrentPrompt: priorAssistant,
+        finalPromptText: "QA_PLEX_YES_123456 answer this current prompt",
+        replayInvalid: true,
+      }),
+    ).toEqual(["QA_PLEX_YES_123456 current ok"]);
+  });
+
+  it("emits a retry notice instead of silently dropping an unanchored stale final", () => {
+    const priorAssistant = makeAssistantMessage([
+      {
+        type: "text",
+        text: "Prior answer",
+        textSignature: JSON.stringify({ v: 1, id: "prior_final", phase: "final_answer" }),
+      },
+    ]);
+    const currentAssistant = makeAssistantMessage([
+      {
+        type: "text",
+        text: "Working on it",
+        textSignature: JSON.stringify({ v: 1, id: "current_commentary", phase: "commentary" }),
+      },
+      {
+        type: "text",
+        text: "Prior answer",
+        textSignature: JSON.stringify({ v: 1, id: "current_final", phase: "final_answer" }),
+      },
+    ]);
+
+    expect(
+      resolveAssistantTextsForFinalPayload({
+        assistantTexts: ["Prior answer"],
+        currentAttemptAssistant: currentAssistant,
+        previousAssistantBeforeCurrentPrompt: priorAssistant,
+        finalPromptText: "What is the status?",
+        replayInvalid: true,
+      }),
+    ).toEqual([STALE_REPLAY_FINAL_ANSWER_NOTICE]);
   });
 });

--- a/src/agents/pi-embedded-runner/run/helpers.test.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.test.ts
@@ -1,6 +1,10 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
-import { resolveFinalAssistantRawText, resolveFinalAssistantVisibleText } from "./helpers.js";
+import {
+  resolveAssistantForFinalPayload,
+  resolveFinalAssistantRawText,
+  resolveFinalAssistantVisibleText,
+} from "./helpers.js";
 
 function makeAssistantMessage(
   content: AssistantMessage["content"],
@@ -71,5 +75,49 @@ describe("resolveFinalAssistantVisibleText", () => {
     ]);
 
     expect(resolveFinalAssistantRawText(lastAssistant)).toBe("<final>keep this</final>");
+  });
+});
+
+describe("resolveAssistantForFinalPayload", () => {
+  it("does not fall back to a prior session assistant when replay is invalid", () => {
+    const priorAssistant = makeAssistantMessage([
+      {
+        type: "text",
+        text: "QA_MODEL previous ok",
+        textSignature: JSON.stringify({ v: 1, id: "prior_final", phase: "final_answer" }),
+      },
+    ]);
+
+    expect(
+      resolveAssistantForFinalPayload({
+        sessionLastAssistant: priorAssistant,
+        replayInvalid: true,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("uses the current attempt assistant even when replay is invalid", () => {
+    const priorAssistant = makeAssistantMessage([
+      {
+        type: "text",
+        text: "QA_MODEL previous ok",
+        textSignature: JSON.stringify({ v: 1, id: "prior_final", phase: "final_answer" }),
+      },
+    ]);
+    const currentAssistant = makeAssistantMessage([
+      {
+        type: "text",
+        text: "QA_PLEX_YES current ok",
+        textSignature: JSON.stringify({ v: 1, id: "current_final", phase: "final_answer" }),
+      },
+    ]);
+
+    expect(
+      resolveAssistantForFinalPayload({
+        currentAttemptAssistant: currentAssistant,
+        sessionLastAssistant: priorAssistant,
+        replayInvalid: true,
+      }),
+    ).toBe(currentAssistant);
   });
 });

--- a/src/agents/pi-embedded-runner/run/helpers.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.ts
@@ -194,3 +194,14 @@ export function resolveFinalAssistantRawText(
   const rawText = (finalAnswerText ?? extractAssistantTextForPhase(lastAssistant) ?? "").trim();
   return rawText || undefined;
 }
+
+export function resolveAssistantForFinalPayload(params: {
+  currentAttemptAssistant?: AssistantMessage | undefined;
+  sessionLastAssistant?: AssistantMessage | undefined;
+  replayInvalid?: boolean;
+}): AssistantMessage | undefined {
+  if (params.currentAttemptAssistant) {
+    return params.currentAttemptAssistant;
+  }
+  return params.replayInvalid ? undefined : params.sessionLastAssistant;
+}

--- a/src/agents/pi-embedded-runner/run/helpers.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.ts
@@ -195,13 +195,97 @@ export function resolveFinalAssistantRawText(
   return rawText || undefined;
 }
 
+export const STALE_REPLAY_FINAL_ANSWER_NOTICE =
+  "The model produced a stale final answer from the previous turn after tool use. I suppressed it instead of sending the wrong answer. Please retry this message.";
+
+function normalizeComparableReplyText(text: string | undefined): string {
+  return (text ?? "").trim().replace(/\s+/gu, " ").toLowerCase();
+}
+
+function resolveCurrentPromptAnchors(finalPromptText: string | undefined): string[] {
+  const prompt = finalPromptText ?? "";
+  const anchors = new Set<string>();
+  for (const match of prompt.matchAll(/\b[A-Z][A-Z0-9_]{5,}\b/gu)) {
+    const marker = match[0]?.trim();
+    if (marker) {
+      anchors.add(marker);
+    }
+  }
+  return [...anchors];
+}
+
+function hasCurrentPromptAnchor(params: {
+  text: string | undefined;
+  finalPromptText?: string | undefined;
+}): boolean {
+  const text = params.text ?? "";
+  if (!text.trim()) {
+    return false;
+  }
+  return resolveCurrentPromptAnchors(params.finalPromptText).some((anchor) =>
+    text.includes(anchor),
+  );
+}
+
+function resolveStaleReplayFinalText(params: {
+  currentAttemptAssistant?: AssistantMessage | undefined;
+  previousAssistantBeforeCurrentPrompt?: AssistantMessage | undefined;
+  replayInvalid?: boolean;
+}): string | undefined {
+  if (!params.replayInvalid || !params.currentAttemptAssistant) {
+    return undefined;
+  }
+  const currentFinal = resolveFinalAssistantVisibleText(params.currentAttemptAssistant);
+  const previousFinal = resolveFinalAssistantVisibleText(
+    params.previousAssistantBeforeCurrentPrompt,
+  );
+  const normalizedCurrent = normalizeComparableReplyText(currentFinal);
+  const normalizedPrevious = normalizeComparableReplyText(previousFinal);
+  if (!normalizedCurrent || !normalizedPrevious || normalizedCurrent !== normalizedPrevious) {
+    return undefined;
+  }
+  return currentFinal;
+}
+
 export function resolveAssistantForFinalPayload(params: {
   currentAttemptAssistant?: AssistantMessage | undefined;
   sessionLastAssistant?: AssistantMessage | undefined;
+  previousAssistantBeforeCurrentPrompt?: AssistantMessage | undefined;
   replayInvalid?: boolean;
 }): AssistantMessage | undefined {
   if (params.currentAttemptAssistant) {
+    if (resolveStaleReplayFinalText(params)) {
+      return undefined;
+    }
     return params.currentAttemptAssistant;
   }
   return params.replayInvalid ? undefined : params.sessionLastAssistant;
+}
+
+export function resolveAssistantTextsForFinalPayload(params: {
+  assistantTexts: string[];
+  currentAttemptAssistant?: AssistantMessage | undefined;
+  previousAssistantBeforeCurrentPrompt?: AssistantMessage | undefined;
+  finalPromptText?: string | undefined;
+  replayInvalid?: boolean;
+}): string[] {
+  const staleFinalText = resolveStaleReplayFinalText(params);
+  if (!staleFinalText) {
+    return params.assistantTexts;
+  }
+  const normalizedStaleFinalText = normalizeComparableReplyText(staleFinalText);
+  const filtered = params.assistantTexts.filter(
+    (text) => normalizeComparableReplyText(text) !== normalizedStaleFinalText,
+  );
+  const commentaryText = extractAssistantTextForPhase(params.currentAttemptAssistant, {
+    phase: "commentary",
+  })?.trim();
+  if (
+    commentaryText &&
+    normalizeComparableReplyText(commentaryText) !== normalizedStaleFinalText &&
+    hasCurrentPromptAnchor({ text: commentaryText, finalPromptText: params.finalPromptText })
+  ) {
+    return filtered.length > 0 ? filtered : [commentaryText];
+  }
+  return filtered.length > 0 ? filtered : [STALE_REPLAY_FINAL_ANSWER_NOTICE];
 }

--- a/src/agents/pi-embedded-runner/run/helpers.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.ts
@@ -229,16 +229,14 @@ function hasCurrentPromptAnchor(params: {
 
 function resolveStaleReplayFinalText(params: {
   currentAttemptAssistant?: AssistantMessage | undefined;
-  previousAssistantBeforeCurrentPrompt?: AssistantMessage | undefined;
+  previousAssistantBeforeTurn?: AssistantMessage | undefined;
   replayInvalid?: boolean;
 }): string | undefined {
   if (!params.replayInvalid || !params.currentAttemptAssistant) {
     return undefined;
   }
   const currentFinal = resolveFinalAssistantVisibleText(params.currentAttemptAssistant);
-  const previousFinal = resolveFinalAssistantVisibleText(
-    params.previousAssistantBeforeCurrentPrompt,
-  );
+  const previousFinal = resolveFinalAssistantVisibleText(params.previousAssistantBeforeTurn);
   const normalizedCurrent = normalizeComparableReplyText(currentFinal);
   const normalizedPrevious = normalizeComparableReplyText(previousFinal);
   if (!normalizedCurrent || !normalizedPrevious || normalizedCurrent !== normalizedPrevious) {
@@ -250,7 +248,7 @@ function resolveStaleReplayFinalText(params: {
 export function resolveAssistantForFinalPayload(params: {
   currentAttemptAssistant?: AssistantMessage | undefined;
   sessionLastAssistant?: AssistantMessage | undefined;
-  previousAssistantBeforeCurrentPrompt?: AssistantMessage | undefined;
+  previousAssistantBeforeTurn?: AssistantMessage | undefined;
   replayInvalid?: boolean;
 }): AssistantMessage | undefined {
   if (params.currentAttemptAssistant) {
@@ -265,7 +263,7 @@ export function resolveAssistantForFinalPayload(params: {
 export function resolveAssistantTextsForFinalPayload(params: {
   assistantTexts: string[];
   currentAttemptAssistant?: AssistantMessage | undefined;
-  previousAssistantBeforeCurrentPrompt?: AssistantMessage | undefined;
+  previousAssistantBeforeTurn?: AssistantMessage | undefined;
   finalPromptText?: string | undefined;
   replayInvalid?: boolean;
 }): string[] {

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -89,6 +89,7 @@ export type EmbeddedRunAttemptResult = {
   toolMetas: Array<{ toolName: string; meta?: string }>;
   lastAssistant: AssistantMessage | undefined;
   currentAttemptAssistant?: AssistantMessage | undefined;
+  previousAssistantBeforeCurrentPrompt?: AssistantMessage | undefined;
   lastToolError?: ToolErrorSummary;
   didSendViaMessagingTool: boolean;
   didSendDeterministicApprovalPrompt?: boolean;

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -89,7 +89,7 @@ export type EmbeddedRunAttemptResult = {
   toolMetas: Array<{ toolName: string; meta?: string }>;
   lastAssistant: AssistantMessage | undefined;
   currentAttemptAssistant?: AssistantMessage | undefined;
-  previousAssistantBeforeCurrentPrompt?: AssistantMessage | undefined;
+  previousAssistantBeforeTurn?: AssistantMessage | undefined;
   lastToolError?: ToolErrorSummary;
   didSendViaMessagingTool: boolean;
   didSendDeterministicApprovalPrompt?: boolean;

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -552,6 +552,15 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("current date");
   });
 
+  it("warns against status-tool drift after the current answer is known", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/clawd",
+    });
+
+    expect(prompt).toContain("The newest user message is authoritative");
+    expect(prompt).toContain("Do not call session_status as a post-answer self-check");
+  });
+
   // The system prompt intentionally does NOT include the current date/time.
   // Only the timezone is included, to keep the prompt stable for caching.
   // See: https://github.com/moltbot/moltbot/commit/66eec295b894bce8333886cfbca3b960c57c4946

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -738,7 +738,7 @@ export function buildAgentSystemPrompt(params: {
           "- sessions_history: fetch session history",
           "- sessions_send: send to another session",
           "- subagents: list/steer/kill sub-agent runs",
-          '- session_status: show usage/time/model state and answer "what model are we using?"',
+          "- session_status: show usage/time/model state and answer explicit model/status/time/configuration questions; do not use it after answering an unrelated task",
         ].join("\n"),
     "TOOLS.md does not control tool availability; it is user guidance for how to use external tools.",
     `For long waits, avoid rapid poll loops: use ${execToolName} with enough yieldMs or ${processToolName}(action=poll, timeout=<ms>).`,
@@ -767,6 +767,8 @@ export function buildAgentSystemPrompt(params: {
         "Narrate only when it helps: multi-step work, complex/challenging problems, sensitive actions (e.g., deletions), or when the user explicitly asks.",
         "Keep narration brief and value-dense; avoid repeating obvious steps.",
         "Use plain human language for narration unless in a technical context.",
+        "The newest user message is authoritative. After any tool result, answer that message directly instead of resuming or answering an older request from transcript history.",
+        "Once you have enough information to answer, stop calling tools and provide the answer. Do not call session_status as a post-answer self-check; use it only when the user explicitly asks about model, status, configuration, current date, or current time.",
         "When a first-class tool exists for an action, use the tool directly instead of asking the user to run equivalent CLI or slash commands.",
         buildExecApprovalPromptGuidance({
           runtimeChannel: params.runtimeInfo?.channel,

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -8,7 +8,8 @@ export const SESSIONS_HISTORY_TOOL_DISPLAY_SUMMARY =
 export const SESSIONS_SEND_TOOL_DISPLAY_SUMMARY = "Send a message to another visible session.";
 export const SESSIONS_SPAWN_TOOL_DISPLAY_SUMMARY = "Spawn sub-agent or ACP sessions.";
 export const SESSIONS_SPAWN_SUBAGENT_TOOL_DISPLAY_SUMMARY = "Spawn sub-agent sessions.";
-export const SESSION_STATUS_TOOL_DISPLAY_SUMMARY = "Show session status, usage, and model state.";
+export const SESSION_STATUS_TOOL_DISPLAY_SUMMARY =
+  "Show session status, usage, and model state when explicitly needed.";
 export const UPDATE_PLAN_TOOL_DISPLAY_SUMMARY = "Track a short structured work plan.";
 
 export function describeSessionsListTool(): string {
@@ -62,7 +63,8 @@ export function describeSessionStatusTool(): string {
     "Show a /status-equivalent session status card for the current or another visible session, including usage, time, cost when available, and linked background task context.",
     'Use `sessionKey="current"` for the current session; do not use UI/client labels such as `openclaw-tui` as session keys.',
     "Optional `model` sets a per-session model override; `model=default` resets overrides.",
-    "Use this for questions like what model is active or how a session is configured.",
+    "Use this for questions like what model is active, what time/date it is, or how a session is configured.",
+    "Do not call this after you already have the answer to an unrelated user request; it is not a post-answer self-check.",
   ].join(" ");
 }
 

--- a/src/gateway/server-methods/agent-session-supersede.test.ts
+++ b/src/gateway/server-methods/agent-session-supersede.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChatAbortControllerEntry } from "../chat-abort.js";
+import {
+  abortSupersededSessionRuns,
+  shouldSupersedeActiveSessionRuns,
+} from "./agent-session-supersede.js";
+import type { GatewayRequestHandlerOptions } from "./types.js";
+
+const runMocks = vi.hoisted(() => ({
+  abortAndDrainEmbeddedPiRun: vi.fn(async () => ({
+    aborted: true,
+    drained: true,
+    forceCleared: false,
+  })),
+  resolveActiveEmbeddedRunSessionId: vi.fn(() => undefined as string | undefined),
+}));
+
+vi.mock("../../agents/pi-embedded-runner/runs.js", () => ({
+  abortAndDrainEmbeddedPiRun: runMocks.abortAndDrainEmbeddedPiRun,
+  resolveActiveEmbeddedRunSessionId: runMocks.resolveActiveEmbeddedRunSessionId,
+}));
+
+function makeContext(): GatewayRequestHandlerOptions["context"] {
+  return {
+    dedupe: new Map(),
+    chatAbortControllers: new Map(),
+    chatRunBuffers: new Map(),
+    chatDeltaSentAt: new Map(),
+    chatDeltaLastBroadcastLen: new Map(),
+    chatAbortedRuns: new Map(),
+    removeChatRun: vi.fn(),
+    agentRunSeq: new Map(),
+    broadcast: vi.fn(),
+    nodeSendToSession: vi.fn(),
+    logGateway: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  } as unknown as GatewayRequestHandlerOptions["context"];
+}
+
+function makeActiveRun(sessionKey: string, sessionId: string): ChatAbortControllerEntry {
+  return {
+    controller: new AbortController(),
+    sessionId,
+    sessionKey,
+    startedAtMs: 100,
+    expiresAtMs: 200,
+    kind: "agent",
+  };
+}
+
+describe("agent session supersede", () => {
+  afterEach(() => {
+    runMocks.abortAndDrainEmbeddedPiRun.mockReset().mockResolvedValue({
+      aborted: true,
+      drained: true,
+      forceCleared: false,
+    });
+    runMocks.resolveActiveEmbeddedRunSessionId.mockReset().mockReturnValue(undefined);
+  });
+
+  it("only supersedes direct external turns", () => {
+    expect(shouldSupersedeActiveSessionRuns(undefined)).toBe(true);
+    expect(shouldSupersedeActiveSessionRuns({ kind: "external_user" })).toBe(true);
+    expect(shouldSupersedeActiveSessionRuns({ kind: "inter_session" })).toBe(false);
+    expect(shouldSupersedeActiveSessionRuns({ kind: "internal_system" })).toBe(false);
+  });
+
+  it("aborts and drains older active runs in the same session", async () => {
+    const context = makeContext();
+    const active = makeActiveRun("agent:main:telegram:direct:8599953238", "session-1");
+    context.chatAbortControllers.set("old-run", active);
+    context.chatAbortControllers.set(
+      "other-session-run",
+      makeActiveRun("agent:main:main", "session-2"),
+    );
+
+    const result = await abortSupersededSessionRuns({
+      context,
+      sessionKey: "agent:main:telegram:direct:8599953238",
+      nextRunId: "new-run",
+    });
+
+    expect(result).toEqual({ ok: true, abortedRunIds: ["old-run"] });
+    expect(active.controller.signal.aborted).toBe(true);
+    expect(context.chatAbortControllers.has("old-run")).toBe(false);
+    expect(context.chatAbortControllers.has("other-session-run")).toBe(true);
+    expect(runMocks.abortAndDrainEmbeddedPiRun).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      sessionKey: "agent:main:telegram:direct:8599953238",
+      settleMs: 15_000,
+      reason: "superseded_agent_turn",
+    });
+    expect(context.dedupe.get("agent:old-run")?.payload).toMatchObject({
+      runId: "old-run",
+      status: "timeout",
+      stopReason: "superseded",
+    });
+  });
+
+  it("returns unavailable when an aborted embedded run does not drain", async () => {
+    runMocks.abortAndDrainEmbeddedPiRun.mockResolvedValueOnce({
+      aborted: true,
+      drained: false,
+      forceCleared: false,
+    });
+    const context = makeContext();
+    context.chatAbortControllers.set("old-run", makeActiveRun("agent:main:main", "session-1"));
+
+    const result = await abortSupersededSessionRuns({
+      context,
+      sessionKey: "agent:main:main",
+      nextRunId: "new-run",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Session agent:main:main is still active; try again in a moment.",
+    });
+    expect(context.logGateway.warn).toHaveBeenCalledWith(
+      "agent turn supersede drain timed out: sessionKey=agent:main:main sessionId=session-1",
+    );
+  });
+});

--- a/src/gateway/server-methods/agent-session-supersede.ts
+++ b/src/gateway/server-methods/agent-session-supersede.ts
@@ -1,0 +1,116 @@
+import {
+  abortAndDrainEmbeddedPiRun,
+  resolveActiveEmbeddedRunSessionId,
+} from "../../agents/pi-embedded-runner/runs.js";
+import type { InputProvenance } from "../../sessions/input-provenance.js";
+import { abortChatRunsForSessionKey } from "../chat-abort.js";
+import { setGatewayDedupeEntry } from "./agent-wait-dedupe.js";
+import type { GatewayRequestHandlerOptions } from "./types.js";
+
+const SUPERSEDED_AGENT_TURN_ABORT_SETTLE_MS = 15_000;
+
+export function shouldSupersedeActiveSessionRuns(
+  inputProvenance: InputProvenance | undefined,
+): boolean {
+  return inputProvenance?.kind !== "inter_session" && inputProvenance?.kind !== "internal_system";
+}
+
+export async function abortSupersededSessionRuns(params: {
+  context: GatewayRequestHandlerOptions["context"];
+  sessionKey: string;
+  nextRunId: string;
+}): Promise<{ ok: true; abortedRunIds: string[] } | { ok: false; error: string }> {
+  const sessionKey = params.sessionKey.trim();
+  if (!sessionKey) {
+    return { ok: true, abortedRunIds: [] };
+  }
+
+  const sessionIdsToDrain = new Set<string>();
+  const activeRunIds: string[] = [];
+  for (const [runId, active] of params.context.chatAbortControllers) {
+    if (runId === params.nextRunId || active.sessionKey !== sessionKey) {
+      continue;
+    }
+    activeRunIds.push(runId);
+    if (active.sessionId) {
+      sessionIdsToDrain.add(active.sessionId);
+    }
+  }
+
+  const activeEmbeddedSessionId = resolveActiveEmbeddedRunSessionId(sessionKey);
+  if (activeEmbeddedSessionId) {
+    sessionIdsToDrain.add(activeEmbeddedSessionId);
+  }
+
+  if (activeRunIds.length === 0 && sessionIdsToDrain.size === 0) {
+    return { ok: true, abortedRunIds: [] };
+  }
+
+  const aborted = abortChatRunsForSessionKey(
+    {
+      chatAbortControllers: params.context.chatAbortControllers,
+      chatRunBuffers: params.context.chatRunBuffers,
+      chatDeltaSentAt: params.context.chatDeltaSentAt,
+      chatDeltaLastBroadcastLen: params.context.chatDeltaLastBroadcastLen,
+      chatAbortedRuns: params.context.chatAbortedRuns,
+      removeChatRun: params.context.removeChatRun,
+      agentRunSeq: params.context.agentRunSeq,
+      broadcast: params.context.broadcast,
+      nodeSendToSession: params.context.nodeSendToSession,
+    },
+    {
+      sessionKey,
+      stopReason: "superseded",
+    },
+  );
+
+  if (aborted.aborted) {
+    params.context.logGateway.info(
+      `agent turn superseded active run(s): sessionKey=${sessionKey} runIds=${aborted.runIds.join(",")}`,
+    );
+    const endedAt = Date.now();
+    for (const runId of aborted.runIds) {
+      setGatewayDedupeEntry({
+        dedupe: params.context.dedupe,
+        key: `agent:${runId}`,
+        entry: {
+          ts: endedAt,
+          ok: true,
+          payload: {
+            runId,
+            status: "timeout" as const,
+            stopReason: "superseded",
+            endedAt,
+          },
+        },
+      });
+    }
+  }
+
+  const drainResults = await Promise.all(
+    [...sessionIdsToDrain].map(async (sessionId) => ({
+      sessionId,
+      result: await abortAndDrainEmbeddedPiRun({
+        sessionId,
+        sessionKey,
+        settleMs: SUPERSEDED_AGENT_TURN_ABORT_SETTLE_MS,
+        reason: "superseded_agent_turn",
+      }),
+    })),
+  );
+
+  const failedDrain = drainResults.find(
+    ({ result }) => result.aborted && !result.drained && !result.forceCleared,
+  );
+  if (failedDrain) {
+    params.context.logGateway.warn(
+      `agent turn supersede drain timed out: sessionKey=${sessionKey} sessionId=${failedDrain.sessionId}`,
+    );
+    return {
+      ok: false,
+      error: `Session ${sessionKey} is still active; try again in a moment.`,
+    };
+  }
+
+  return { ok: true, abortedRunIds: aborted.runIds };
+}

--- a/src/gateway/server-methods/agent-wait-dedupe.test.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.test.ts
@@ -329,6 +329,38 @@ describe("agent wait dedupe helper", () => {
     });
   });
 
+  it("preserves a superseded cancel snapshot when late completion writes the same key", () => {
+    const dedupe = new Map();
+    const runId = "run-superseded-wins";
+
+    setRunEntry({
+      dedupe,
+      kind: "agent",
+      runId,
+      ts: 100,
+      payload: { runId, status: "timeout", stopReason: "superseded", endedAt: 100 },
+    });
+    setRunEntry({
+      dedupe,
+      kind: "agent",
+      runId,
+      ts: 200,
+      payload: { runId, status: "ok", endedAt: 200 },
+    });
+
+    expect(
+      readTerminalSnapshotFromGatewayDedupe({
+        dedupe,
+        runId,
+      }),
+    ).toEqual({
+      status: "timeout",
+      endedAt: 100,
+      error: undefined,
+      stopReason: "superseded",
+    });
+  });
+
   it("preserves an RPC cancel snapshot when late rejection writes the same chat key", () => {
     const dedupe = new Map();
     const runId = "run-cancel-chat-error";

--- a/src/gateway/server-methods/agent-wait-dedupe.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.ts
@@ -238,7 +238,10 @@ export function setGatewayDedupeEntry(params: {
   const existing = params.dedupe.get(params.key);
   const existingSnapshot = existing ? readTerminalSnapshotFromDedupeEntry(existing) : null;
   const incomingSnapshot = readTerminalSnapshotFromDedupeEntry(params.entry);
-  if (existingSnapshot?.status === "timeout" && existingSnapshot.stopReason === "rpc") {
+  if (
+    existingSnapshot?.status === "timeout" &&
+    (existingSnapshot.stopReason === "rpc" || existingSnapshot.stopReason === "superseded")
+  ) {
     return;
   }
   params.dedupe.set(params.key, params.entry);

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -118,6 +118,10 @@ import {
 } from "../session-utils.js";
 import { formatForLog } from "../ws-log.js";
 import { waitForAgentJob } from "./agent-job.js";
+import {
+  abortSupersededSessionRuns,
+  shouldSupersedeActiveSessionRuns,
+} from "./agent-session-supersede.js";
 import { injectTimestamp, timestampOptsFromConfig } from "./agent-timestamp.js";
 import {
   readTerminalSnapshotFromGatewayDedupe,
@@ -1085,6 +1089,20 @@ export const agentHandlers: GatewayRequestHandlers = {
     }
 
     const runId = idem;
+    if (resolvedSessionKey && shouldSupersedeActiveSessionRuns(inputProvenance)) {
+      const superseded = await abortSupersededSessionRuns({
+        context,
+        sessionKey: resolvedSessionKey,
+        nextRunId: runId,
+      });
+      if (!superseded.ok) {
+        respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, superseded.error), {
+          runId,
+          error: superseded.error,
+        });
+        return;
+      }
+    }
     const connId = typeof client?.connId === "string" ? client.connId : undefined;
     const wantsToolEvents = hasGatewayClientCap(
       client?.connect?.caps,


### PR DESCRIPTION
## Summary
- Prevent stale OpenAI/Codex replay finals from being delivered after a newer Telegram/tool turn.
- Suppress repeated prior final answers, prefer current anchored commentary when available, and emit a retry notice instead of nonsense when the final payload is stale.
- Track the previous visible assistant before each turn so tool-use assistant frames are not mistaken for the prior user-visible answer.
- Supersede overlapping agent turns so late completions cannot overwrite a newer turn's payload.

## Tests
- Local: `npx --yes pnpm@10.33.2 exec vitest run src/agents/pi-embedded-runner/run/helpers.test.ts src/agents/pi-embedded-runner/run/payloads.test.ts src/agents/pi-embedded-runner/run/payloads.errors.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/openai-ws-stream.test.ts src/agents/system-prompt.test.ts`
- Local: `npx --yes pnpm@10.33.2 build`
- Zeus live: focused Vitest suite passed after cherry-pick deploy.
- Zeus live: `npx --yes pnpm@10.33.2 build` and `npx --yes pnpm@10.33.2 ui:build` passed.
- Zeus live: gateway restart passed `/health`, `openclaw models status --json`, and `openclaw channels status --probe --json`.
- Zeus live Telegram: reset poisoned direct session, then five expected-answer prompts passed through the live Telegram path on `openai-codex/gpt-5.5`: default model, gateway model status, media/Plex-style tool check, GitHub PR check, and workspace memory check.
- ZeusChat live UI: dedicated Playwright profile loaded the web UI, switched active chat from GPT 5.5 to GPT 5.4 and back to GPT 5.5, and captured `/tmp/zeuschat-live-ui-gpt55-transition.png`.

## Tracking
Fixes #4.
