### PR TITLE
Stop direct Telegram NO_REPLY fallback chatter

### DIFF
--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -333,7 +333,12 @@ export async function deliverAgentCommandResult(params: {
           accountId: resolvedAccountId,
         })
       : normalizedReplyPayloads;
-  const outboundPayloadPlan = createOutboundPayloadPlan(mediaNormalizedReplyPayloads);
+  const outboundPayloadPlan = createOutboundPayloadPlan(mediaNormalizedReplyPayloads, {
+    cfg,
+    sessionKey: outboundSession?.policyKey ?? effectiveSessionKey,
+    surface: deliveryChannel,
+    conversationType: outboundSession?.conversationType,
+  });
   const normalizedPayloads = projectOutboundPayloadPlanForJson(outboundPayloadPlan);
   const resultMeta = mergeResultMetaOverrides(result.meta, opts.resultMetaOverrides);
   if (opts.json) {

--- a/src/agents/prompt-composition.test.ts
+++ b/src/agents/prompt-composition.test.ts
@@ -76,7 +76,7 @@ describe("prompt composition invariants", () => {
     expect(steady.systemPrompt).toBe(eventTurn.systemPrompt);
   });
 
-  it("includes direct-chat guidance that routes NO_REPLY through the default rewrite path", () => {
+  it("includes direct-chat guidance that forbids NO_REPLY by default", () => {
     const directScenario = fixture.scenarios.find(
       (entry) => entry.scenario === "auto-reply-direct",
     );
@@ -84,8 +84,10 @@ describe("prompt composition invariants", () => {
     const first = getTurn(directScenario!, "t1");
 
     expect(first.systemPrompt).toContain("You are in a Slack direct conversation.");
-    expect(first.systemPrompt).toContain('reply with exactly "NO_REPLY"');
-    expect(first.systemPrompt).toContain("so OpenClaw can send a short fallback reply");
+    expect(first.systemPrompt).toContain(
+      'Do not use "NO_REPLY" as your final answer in this conversation.',
+    );
+    expect(first.systemPrompt).not.toContain("so OpenClaw can send a short fallback reply");
     expect(first.systemPrompt).not.toContain("## Silent Replies");
   });
 

--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -78,7 +78,9 @@ describe("group runtime loading", () => {
         silentReplyRewrite: true,
         silentToken: "NO_REPLY",
       }),
-    ).toContain("so OpenClaw can send a short fallback reply");
+    ).toBe(
+      'You are in a Telegram direct conversation. Your replies are automatically sent to this conversation. Do not use "NO_REPLY" as your final answer in this conversation.',
+    );
 
     expect(
       groups.buildDirectChatContext({

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -295,10 +295,6 @@ export function buildDirectChatContext(params: {
     lines.push(
       `If no response is needed, reply with exactly "${params.silentToken}" (and nothing else) so OpenClaw stays silent.`,
     );
-  } else if (params.silentReplyRewrite === true) {
-    lines.push(
-      `If no response is needed, reply with exactly "${params.silentToken}" (and nothing else) so OpenClaw can send a short fallback reply.`,
-    );
   } else {
     lines.push(`Do not use "${params.silentToken}" as your final answer in this conversation.`);
   }

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -5,6 +5,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { generateSecureInt } from "../../infra/secure-random.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
+  classifySilentReplyConversationType,
   resolveSilentReplyRewriteText,
   type SilentReplyConversationType,
 } from "../../shared/silent-reply-policy.js";
@@ -146,6 +147,20 @@ function resolveSilentFinalPayload(params: {
     conversationType: context.conversationType,
   });
   if (resolvedSettings.policy === "allow") {
+    return undefined;
+  }
+  const conversationType = classifySilentReplyConversationType({
+    sessionKey: context.sessionKey,
+    surface: context.surface,
+    conversationType: context.conversationType,
+  });
+  if (conversationType === "direct") {
+    silentReplyLogger.warn("dropping exact NO_REPLY final payload for direct conversation", {
+      hasSessionKey: Boolean(context.sessionKey),
+      surface: context.surface,
+      conversationType,
+      resolvedPolicy: resolvedSettings.policy,
+    });
     return undefined;
   }
   if (resolvedSettings.rewrite) {

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -21,7 +21,7 @@ describe("createReplyDispatcher", () => {
     expect(deliver.mock.calls[1]?.[0]?.text).toBe(`interject.${SILENT_REPLY_TOKEN}`);
   });
 
-  it("rewrites exact NO_REPLY final payloads for direct sessions where rewrite is enabled", async () => {
+  it("drops exact NO_REPLY final payloads for direct sessions even when rewrite is enabled", async () => {
     const deliver = vi.fn().mockResolvedValue(undefined);
     const cfg: OpenClawConfig = {
       agents: {
@@ -46,15 +46,13 @@ describe("createReplyDispatcher", () => {
       },
     });
 
-    expect(dispatcher.sendFinalReply({ text: SILENT_REPLY_TOKEN })).toBe(true);
+    expect(dispatcher.sendFinalReply({ text: SILENT_REPLY_TOKEN })).toBe(false);
 
     await dispatcher.waitForIdle();
-    expect(deliver).toHaveBeenCalledTimes(1);
-    expect(deliver.mock.calls[0]?.[0]?.text).not.toBe(SILENT_REPLY_TOKEN);
-    expect(deliver.mock.calls[0]?.[0]?.text).toBeTruthy();
+    expect(deliver).not.toHaveBeenCalled();
   });
 
-  it("preserves exact NO_REPLY final payloads for direct sessions where rewrite is disabled", async () => {
+  it("drops exact NO_REPLY final payloads for direct sessions where rewrite is disabled", async () => {
     const deliver = vi.fn().mockResolvedValue(undefined);
     const cfg: OpenClawConfig = {
       agents: {
@@ -79,11 +77,10 @@ describe("createReplyDispatcher", () => {
       },
     });
 
-    expect(dispatcher.sendFinalReply({ text: SILENT_REPLY_TOKEN })).toBe(true);
+    expect(dispatcher.sendFinalReply({ text: SILENT_REPLY_TOKEN })).toBe(false);
 
     await dispatcher.waitForIdle();
-    expect(deliver).toHaveBeenCalledTimes(1);
-    expect(deliver.mock.calls[0]?.[0]?.text).toBe(SILENT_REPLY_TOKEN);
+    expect(deliver).not.toHaveBeenCalled();
   });
 
   it("still drops exact NO_REPLY final payloads for group sessions where silence is allowed", async () => {

--- a/src/config/silent-reply.test.ts
+++ b/src/config/silent-reply.test.ts
@@ -71,7 +71,7 @@ describe("silent reply config resolution", () => {
   });
 
   it("resolves rewrite defaults and surface overrides by conversation type", () => {
-    expect(resolveSilentReplyRewriteEnabled({ surface: "webchat" })).toBe(true);
+    expect(resolveSilentReplyRewriteEnabled({ surface: "webchat" })).toBe(false);
     expect(
       resolveSilentReplyRewriteEnabled({
         sessionKey: "agent:main:telegram:group:123",

--- a/src/gateway/server.sessions.reset-models.test.ts
+++ b/src/gateway/server.sessions.reset-models.test.ts
@@ -50,6 +50,45 @@ test("sessions.reset recomputes model from defaults instead of stale runtime mod
   await expect(fs.stat(reset.payload?.entry.sessionFile as string)).resolves.toBeTruthy();
 });
 
+test("sessions.reset rewrites default transcript files to the new session id", async () => {
+  const { storePath } = await createSessionStoreDir();
+  testState.agentConfig = {
+    model: {
+      primary: "openai/gpt-test-a",
+    },
+  };
+  const sessionsDir = await fs.realpath(path.dirname(storePath));
+  const oldSessionId = "sess-default-file-before-reset";
+  const oldSessionFile = path.join(sessionsDir, `${oldSessionId}.jsonl`);
+  await fs.writeFile(oldSessionFile, `${JSON.stringify({ role: "user", content: "old" })}\n`);
+
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry(oldSessionId, {
+        sessionFile: oldSessionFile,
+      }),
+    },
+  });
+
+  const reset = await directSessionReq<{
+    ok: true;
+    entry: {
+      sessionId: string;
+      sessionFile?: string;
+    };
+  }>("sessions.reset", { key: "main" });
+
+  expect(reset.ok).toBe(true);
+  const newSessionId = reset.payload?.entry.sessionId;
+  const newSessionFile = reset.payload?.entry.sessionFile;
+  expect(newSessionId).toBeTruthy();
+  expect(newSessionId).not.toBe(oldSessionId);
+  expect(newSessionFile).toBeTruthy();
+  expect(newSessionFile).not.toBe(oldSessionFile);
+  expect(path.basename(newSessionFile as string)).toBe(`${newSessionId}.jsonl`);
+  await expect(fs.stat(newSessionFile as string)).resolves.toBeTruthy();
+});
+
 test("sessions.reset preserves legacy explicit model overrides without modelOverrideSource", async () => {
   const { storePath } = await createSessionStoreDir();
   testState.agentConfig = {

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -66,6 +66,39 @@ function stripRuntimeModelState(entry?: SessionEntry): SessionEntry | undefined 
   };
 }
 
+function rewriteDefaultSessionFileForReset(params: {
+  sessionFile?: string;
+  previousSessionId?: string;
+  nextSessionId: string;
+}): string | undefined {
+  const trimmed = params.sessionFile?.trim();
+  const previousSessionId = params.previousSessionId?.trim();
+  if (!trimmed || !previousSessionId) {
+    return undefined;
+  }
+  const base = path.basename(trimmed);
+  if (!base.endsWith(".jsonl")) {
+    return undefined;
+  }
+  const withoutExt = base.slice(0, -".jsonl".length);
+  if (withoutExt === previousSessionId) {
+    return path.join(path.dirname(trimmed), `${params.nextSessionId}.jsonl`);
+  }
+  if (withoutExt.startsWith(`${previousSessionId}-topic-`)) {
+    return path.join(
+      path.dirname(trimmed),
+      `${params.nextSessionId}${base.slice(previousSessionId.length)}`,
+    );
+  }
+  const forkMatch = withoutExt.match(
+    /^(\d{4}-\d{2}-\d{2}T[\w-]+(?:Z|[+-]\d{2}(?:-\d{2})?)?)_(.+)$/,
+  );
+  if (forkMatch?.[2] === previousSessionId) {
+    return path.join(path.dirname(trimmed), `${forkMatch[1]}_${params.nextSessionId}.jsonl`);
+  }
+  return undefined;
+}
+
 export function archiveSessionTranscriptsForSession(params: {
   sessionId: string | undefined;
   storePath: string;
@@ -555,9 +588,18 @@ export async function performGatewaySessionReset(params: {
     oldSessionFile = currentEntry?.sessionFile;
     const now = Date.now();
     const nextSessionId = randomUUID();
+    const rewrittenSessionFile = rewriteDefaultSessionFileForReset({
+      sessionFile: currentEntry?.sessionFile,
+      previousSessionId: currentEntry?.sessionId,
+      nextSessionId,
+    });
     const sessionFile = resolveSessionFilePath(
       nextSessionId,
-      currentEntry?.sessionFile ? { sessionFile: currentEntry.sessionFile } : undefined,
+      rewrittenSessionFile
+        ? { sessionFile: rewrittenSessionFile }
+        : currentEntry?.sessionFile
+          ? { sessionFile: currentEntry.sessionFile }
+          : undefined,
       resolveSessionFilePathOptions({
         storePath,
         agentId: sessionAgentId,

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -1580,7 +1580,7 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
-  it("applies silent-reply rewrite policy from the outbound session", async () => {
+  it("does not rewrite direct-session silent replies into fallback chatter", async () => {
     const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m-silent", roomId: "!room" });
     const cfg: OpenClawConfig = {
       agents: {
@@ -1606,9 +1606,7 @@ describe("deliverOutboundPayloads", () => {
       },
     });
 
-    expect(sendMatrix).toHaveBeenCalledTimes(1);
-    expect(sendMatrix.mock.calls[0]?.[1]).toBeTruthy();
-    expect(sendMatrix.mock.calls[0]?.[1]).not.toBe("NO_REPLY");
+    expect(sendMatrix).not.toHaveBeenCalled();
   });
 
   it("keeps allowed group silent replies silent during outbound delivery", async () => {

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -190,7 +190,7 @@ describe("normalizeReplyPayloadsForDelivery", () => {
     ]);
   });
 
-  it("rewrites bare silent replies for direct conversations where silence is disallowed", () => {
+  it("drops bare silent replies for direct conversations where silence is disallowed", () => {
     const cfg: OpenClawConfig = {
       agents: {
         defaults: {
@@ -204,16 +204,15 @@ describe("normalizeReplyPayloadsForDelivery", () => {
     };
 
     const sessionKey = "agent:main:telegram:direct:123";
-    const projected = projectOutboundPayloadPlanForDelivery(
-      createOutboundPayloadPlan([{ text: "NO_REPLY" }], {
-        cfg,
-        sessionKey,
-        surface: "telegram",
-      }),
-    );
-    expect(projected).toHaveLength(1);
-    expect(projected[0]?.text?.trim()).toBeTruthy();
-    expect(projected[0]?.text?.trim()).not.toBe("NO_REPLY");
+    expect(
+      projectOutboundPayloadPlanForDelivery(
+        createOutboundPayloadPlan([{ text: "NO_REPLY" }], {
+          cfg,
+          sessionKey,
+          surface: "telegram",
+        }),
+      ),
+    ).toEqual([]);
   });
 
   it("drops bare silent replies for groups when policy allows silence", () => {
@@ -300,22 +299,19 @@ describe("normalizeReplyPayloadsForDelivery", () => {
       }
     });
 
-    it("falls back to the visible rewrite path when the query throws", () => {
+    it("still drops direct bare silent replies when the pending-child query throws", () => {
       const previousQuery = registerPendingSpawnedChildrenQuery(() => {
         throw new Error("registry unavailable");
       });
       try {
-        const delivery = planSilent("agent:main:telegram:direct:789");
-        expect(delivery).toHaveLength(1);
-        expect(delivery[0]?.text).toBeTruthy();
-        expect(delivery[0]?.text).not.toBe("NO_REPLY");
+        expect(planSilent("agent:main:telegram:direct:789")).toEqual([]);
       } finally {
         registerPendingSpawnedChildrenQuery(previousQuery);
       }
     });
   });
 
-  it("keeps bare NO_REPLY visible when silence is disallowed and rewrite is disabled", () => {
+  it("drops bare NO_REPLY for direct conversations when silence is disallowed and rewrite is disabled", () => {
     const cfg: OpenClawConfig = {
       agents: {
         defaults: {
@@ -339,11 +335,35 @@ describe("normalizeReplyPayloadsForDelivery", () => {
           surface: "telegram",
         }),
       ),
-    ).toEqual([
-      expect.objectContaining({
-        text: "NO_REPLY",
+    ).toEqual([]);
+  });
+
+  it("rewrites bare NO_REPLY for non-direct conversations when rewrite is explicitly enabled", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          silentReply: {
+            direct: "disallow",
+            group: "allow",
+            internal: "disallow",
+          },
+          silentReplyRewrite: {
+            internal: true,
+          },
+        },
+      },
+    };
+
+    const projected = projectOutboundPayloadPlanForDelivery(
+      createOutboundPayloadPlan([{ text: "NO_REPLY" }], {
+        cfg,
+        sessionKey: "agent:main:maintenance",
+        surface: "internal",
       }),
-    ]);
+    );
+    expect(projected).toHaveLength(1);
+    expect(projected[0]?.text?.trim()).toBeTruthy();
+    expect(projected[0]?.text?.trim()).not.toBe("NO_REPLY");
   });
 
   it("is idempotent for already-normalized delivery payloads", () => {

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -18,6 +18,7 @@ import {
   type ReplyPayloadDelivery,
 } from "../../interactive/payload.js";
 import {
+  classifySilentReplyConversationType,
   resolveSilentReplyRewriteText,
   type SilentReplyConversationType,
 } from "../../shared/silent-reply-policy.js";
@@ -193,6 +194,11 @@ export function createOutboundPayloadPlan(
     surface: context.surface,
     conversationType: context.conversationType,
   });
+  const silentReplyConversationType = classifySilentReplyConversationType({
+    sessionKey: context.sessionKey,
+    surface: context.surface,
+    conversationType: context.conversationType,
+  });
   const hasPendingSpawnedChildren =
     context.hasPendingSpawnedChildren ?? resolvePendingSpawnedChildren(context.sessionKey);
   const prepared: PreparedOutboundPayloadPlanEntry[] = [];
@@ -232,6 +238,9 @@ export function createOutboundPayloadPlan(
       resolvedSilentReplySettings.policy === "allow" ||
       hasPendingSpawnedChildren
     ) {
+      continue;
+    }
+    if (silentReplyConversationType === "direct") {
       continue;
     }
     if (!resolvedSilentReplySettings.rewrite) {

--- a/src/shared/silent-reply-policy.ts
+++ b/src/shared/silent-reply-policy.ts
@@ -15,7 +15,7 @@ export const DEFAULT_SILENT_REPLY_POLICY: Record<SilentReplyConversationType, Si
 };
 
 export const DEFAULT_SILENT_REPLY_REWRITE: Record<SilentReplyConversationType, boolean> = {
-  direct: true,
+  direct: false,
   group: false,
   internal: false,
 };


### PR DESCRIPTION
## Summary
- Disable default direct-chat silent reply rewrites so Telegram/WebChat do not turn `NO_REPLY` into visible fallback chatter.
- Make direct chat prompt guidance forbid `NO_REPLY` instead of teaching the model to use it for fallback prose.
- Drop exact direct-session `NO_REPLY` at dispatcher/outbound delivery boundaries instead of sending a synthetic phrase.
- Fix `sessions.reset` so default transcript files rotate to the new session id instead of replaying the old JSONL.
- Pass outbound session context into CLI/agent delivery payload planning so silent policy classification uses the real session.

Fixes #7.
Fixes #10.

## Verification
- `npx --yes pnpm@10.33.2 exec vitest run src/config/silent-reply.test.ts src/shared/silent-reply-policy.test.ts src/auto-reply/reply/groups.test.ts src/auto-reply/reply/reply-flow.test.ts src/agents/prompt-composition.test.ts src/infra/outbound/payloads.test.ts src/infra/outbound/deliver.test.ts src/gateway/server.sessions.reset-models.test.ts`
- `npx --yes pnpm@10.33.2 build`
