### PR TITLE
Repair mismatched reset transcript files

### DIFF
--- a/src/gateway/server.sessions.reset-models.test.ts
+++ b/src/gateway/server.sessions.reset-models.test.ts
@@ -89,6 +89,47 @@ test("sessions.reset rewrites default transcript files to the new session id", a
   await expect(fs.stat(newSessionFile as string)).resolves.toBeTruthy();
 });
 
+test("sessions.reset repairs mismatched default UUID transcript files", async () => {
+  const { storePath } = await createSessionStoreDir();
+  testState.agentConfig = {
+    model: {
+      primary: "openai/gpt-test-a",
+    },
+  };
+  const sessionsDir = await fs.realpath(path.dirname(storePath));
+  const currentSessionId = "d2b274c7-1759-474d-bb6b-bad3d88a5172";
+  const staleFileSessionId = "e21b2a10-f608-4ddf-b1bc-f30bb662138a";
+  const staleSessionFile = path.join(sessionsDir, `${staleFileSessionId}.jsonl`);
+  await fs.writeFile(staleSessionFile, `${JSON.stringify({ role: "user", content: "stale" })}\n`);
+
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry(currentSessionId, {
+        sessionFile: staleSessionFile,
+      }),
+    },
+  });
+
+  const reset = await directSessionReq<{
+    ok: true;
+    entry: {
+      sessionId: string;
+      sessionFile?: string;
+    };
+  }>("sessions.reset", { key: "main" });
+
+  expect(reset.ok).toBe(true);
+  const newSessionId = reset.payload?.entry.sessionId;
+  const newSessionFile = reset.payload?.entry.sessionFile;
+  expect(newSessionId).toBeTruthy();
+  expect(newSessionId).not.toBe(currentSessionId);
+  expect(newSessionId).not.toBe(staleFileSessionId);
+  expect(newSessionFile).toBeTruthy();
+  expect(newSessionFile).not.toBe(staleSessionFile);
+  expect(path.basename(newSessionFile as string)).toBe(`${newSessionId}.jsonl`);
+  await expect(fs.stat(newSessionFile as string)).resolves.toBeTruthy();
+});
+
 test("sessions.reset preserves legacy explicit model overrides without modelOverrideSource", async () => {
   const { storePath } = await createSessionStoreDir();
   testState.agentConfig = {

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -99,6 +99,21 @@ function rewriteDefaultSessionFileForReset(params: {
   return undefined;
 }
 
+function isDefaultUuidSessionFilePath(sessionFile?: string): boolean {
+  const trimmed = sessionFile?.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const base = path.basename(trimmed);
+  if (!base.endsWith(".jsonl")) {
+    return false;
+  }
+  const withoutExt = base.slice(0, -".jsonl".length);
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    withoutExt,
+  );
+}
+
 export function archiveSessionTranscriptsForSession(params: {
   sessionId: string | undefined;
   storePath: string;
@@ -593,12 +608,16 @@ export async function performGatewaySessionReset(params: {
       previousSessionId: currentEntry?.sessionId,
       nextSessionId,
     });
+    const preservedSessionFile =
+      currentEntry?.sessionFile && !isDefaultUuidSessionFilePath(currentEntry.sessionFile)
+        ? currentEntry.sessionFile
+        : undefined;
     const sessionFile = resolveSessionFilePath(
       nextSessionId,
       rewrittenSessionFile
         ? { sessionFile: rewrittenSessionFile }
-        : currentEntry?.sessionFile
-          ? { sessionFile: currentEntry.sessionFile }
+        : preservedSessionFile
+          ? { sessionFile: preservedSessionFile }
           : undefined,
       resolveSessionFilePathOptions({
         storePath,


### PR DESCRIPTION
## Summary
- Treat UUID-shaped transcript JSONL paths as default session files, even when they already mismatch the stored session id.
- On reset, create a fresh transcript named after the new session id instead of preserving the stale UUID file.
- Preserve custom non-default transcript paths for owned child sessions.

Fixes #12.

## Verification
- `npx --yes pnpm@10.33.2 exec vitest run src/gateway/server.sessions.reset-models.test.ts`
- `npx --yes pnpm@10.33.2 build`
