### PR TITLE
Promote substantive stale-replay commentary

### DIFF
--- a/src/agents/pi-embedded-runner/run/helpers.test.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.test.ts
@@ -187,7 +187,71 @@ describe("resolveAssistantTextsForFinalPayload", () => {
     ).toEqual(["QA_PLEX_YES_123456 current ok"]);
   });
 
-  it("emits a retry notice instead of silently dropping an unanchored stale final", () => {
+  it("promotes unanchored substantive commentary when replay-invalid final text repeats the prior answer", () => {
+    const priorAssistant = makeAssistantMessage([
+      {
+        type: "text",
+        text: "No recent Plex additions.",
+        textSignature: JSON.stringify({ v: 1, id: "prior_final", phase: "final_answer" }),
+      },
+    ]);
+    const currentAssistant = makeAssistantMessage([
+      {
+        type: "text",
+        text: "I checked Plex and Django Unchained is the newest library addition.",
+        textSignature: JSON.stringify({ v: 1, id: "current_commentary", phase: "commentary" }),
+      },
+      {
+        type: "text",
+        text: "No recent Plex additions.",
+        textSignature: JSON.stringify({ v: 1, id: "current_final", phase: "final_answer" }),
+      },
+    ]);
+
+    expect(
+      resolveAssistantTextsForFinalPayload({
+        assistantTexts: ["No recent Plex additions."],
+        currentAttemptAssistant: currentAssistant,
+        previousAssistantBeforeTurn: priorAssistant,
+        finalPromptText: "What's new on Plex?",
+        replayInvalid: true,
+      }),
+    ).toEqual(["I checked Plex and Django Unchained is the newest library addition."]);
+  });
+
+  it("promotes short unanchored substantive commentary when replay-invalid final text repeats the prior answer", () => {
+    const priorAssistant = makeAssistantMessage([
+      {
+        type: "text",
+        text: "Yesterday's SAB history is unchanged.",
+        textSignature: JSON.stringify({ v: 1, id: "prior_final", phase: "final_answer" }),
+      },
+    ]);
+    const currentAssistant = makeAssistantMessage([
+      {
+        type: "text",
+        text: "No new SAB grabs.",
+        textSignature: JSON.stringify({ v: 1, id: "current_commentary", phase: "commentary" }),
+      },
+      {
+        type: "text",
+        text: "Yesterday's SAB history is unchanged.",
+        textSignature: JSON.stringify({ v: 1, id: "current_final", phase: "final_answer" }),
+      },
+    ]);
+
+    expect(
+      resolveAssistantTextsForFinalPayload({
+        assistantTexts: ["Yesterday's SAB history is unchanged."],
+        currentAttemptAssistant: currentAssistant,
+        previousAssistantBeforeTurn: priorAssistant,
+        finalPromptText: "What are the latest SAB grabs?",
+        replayInvalid: true,
+      }),
+    ).toEqual(["No new SAB grabs."]);
+  });
+
+  it("emits a retry notice instead of promoting progress-only commentary", () => {
     const priorAssistant = makeAssistantMessage([
       {
         type: "text",

--- a/src/agents/pi-embedded-runner/run/helpers.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.ts
@@ -227,6 +227,36 @@ function hasCurrentPromptAnchor(params: {
   );
 }
 
+function isProgressOnlyCommentaryText(text: string | undefined): boolean {
+  const normalized = normalizeComparableReplyText(text);
+  if (!normalized) {
+    return true;
+  }
+  return (
+    /^(?:working(?: on (?:it|that|this))?|checking(?: now)?|looking (?:into|up) (?:it|that|this)?|one moment|hang on|hold on)\.?$/iu.test(
+      normalized,
+    ) ||
+    /^(?:let me|i(?:'ll| will| am going to|'m going to)|first[, ]+i(?:'ll| will)|next[, ]+i(?:'ll| will))\b/iu.test(
+      normalized,
+    ) ||
+    /^i(?:'m| am) (?:checking|looking|going to|working on)\b/iu.test(normalized)
+  );
+}
+
+function isPromotableCurrentCommentaryText(params: {
+  text: string | undefined;
+  finalPromptText?: string | undefined;
+}): boolean {
+  const text = params.text ?? "";
+  if (!text.trim()) {
+    return false;
+  }
+  if (hasCurrentPromptAnchor({ text, finalPromptText: params.finalPromptText })) {
+    return true;
+  }
+  return !isProgressOnlyCommentaryText(text);
+}
+
 function resolveStaleReplayFinalText(params: {
   currentAttemptAssistant?: AssistantMessage | undefined;
   previousAssistantBeforeTurn?: AssistantMessage | undefined;
@@ -281,7 +311,10 @@ export function resolveAssistantTextsForFinalPayload(params: {
   if (
     commentaryText &&
     normalizeComparableReplyText(commentaryText) !== normalizedStaleFinalText &&
-    hasCurrentPromptAnchor({ text: commentaryText, finalPromptText: params.finalPromptText })
+    isPromotableCurrentCommentaryText({
+      text: commentaryText,
+      finalPromptText: params.finalPromptText,
+    })
   ) {
     return filtered.length > 0 ? filtered : [commentaryText];
   }


### PR DESCRIPTION
Closes #14.

## Summary
- Promotes substantive current-turn commentary when replay-invalid final_answer repeats the previous turn.
- Keeps progress-only commentary such as "Working on it" on the guarded retry-notice path.
- Adds unanchored real-prompt regressions for Plex/SAB-style Telegram turns.

## Tests
- npx --yes pnpm@10.33.2 exec vitest run src/agents/pi-embedded-runner/run/helpers.test.ts
- npx --yes pnpm@10.33.2 exec vitest run src/agents/pi-embedded-runner/run/helpers.test.ts src/infra/outbound/payloads.test.ts src/infra/outbound/deliver.test.ts src/auto-reply/reply/reply-flow.test.ts src/gateway/server.sessions.reset-models.test.ts
- npx --yes pnpm@10.33.2 build